### PR TITLE
Decouple metrics from core services

### DIFF
--- a/internal/adapters/metrics/BUILD.bazel
+++ b/internal/adapters/metrics/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "metrics",
+    srcs = ["prometheus_metrics.go"],
+    importpath = "github.com/sufield/ephemos/internal/adapters/metrics",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/core/services",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promauto",
+    ],
+)

--- a/internal/adapters/metrics/prometheus_metrics.go
+++ b/internal/adapters/metrics/prometheus_metrics.go
@@ -1,0 +1,117 @@
+// Package metrics provides Prometheus-based implementations of service metrics reporting.
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sufield/ephemos/internal/core/services"
+)
+
+var (
+	// Certificate cache metrics
+	certCacheHitsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "ephemos_cert_cache_hits_total",
+		Help: "Total number of certificate cache hits",
+	})
+
+	certCacheMissesCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "ephemos_cert_cache_misses_total",
+		Help: "Total number of certificate cache misses",
+	})
+
+	// Trust bundle cache metrics
+	bundleCacheHitsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "ephemos_bundle_cache_hits_total",
+		Help: "Total number of trust bundle cache hits",
+	})
+
+	bundleCacheMissesCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "ephemos_bundle_cache_misses_total",
+		Help: "Total number of trust bundle cache misses",
+	})
+
+	// Certificate refresh metrics
+	certRefreshCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ephemos_cert_refresh_total",
+		Help: "Total number of certificate refreshes",
+	}, []string{"reason"}) // reason: expired, proactive, cache_miss
+
+	certRefreshDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "ephemos_cert_refresh_duration_seconds",
+		Help:    "Duration of certificate refresh operations",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	// Certificate expiry gauge
+	certExpiryTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemos_cert_expiry_timestamp_seconds",
+		Help: "Unix timestamp when the cached certificate will expire",
+	}, []string{"service_name"})
+
+	// Certificate validation metrics
+	certValidationCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ephemos_cert_validation_total",
+		Help: "Total number of certificate validations",
+	}, []string{"result"}) // result: success, failure
+
+	// Retry metrics
+	providerRetryCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ephemos_provider_retry_total",
+		Help: "Total number of provider retry attempts",
+	}, []string{"provider_type", "attempt"})
+)
+
+// PrometheusMetrics implements services.MetricsReporter using Prometheus.
+type PrometheusMetrics struct{}
+
+// NewPrometheusMetrics creates a new Prometheus metrics reporter.
+func NewPrometheusMetrics() services.MetricsReporter {
+	return &PrometheusMetrics{}
+}
+
+// RecordCacheHit records a cache hit.
+func (m *PrometheusMetrics) RecordCacheHit(cacheType string) {
+	switch cacheType {
+	case "certificate":
+		certCacheHitsCounter.Inc()
+	case "bundle":
+		bundleCacheHitsCounter.Inc()
+	}
+}
+
+// RecordCacheMiss records a cache miss.
+func (m *PrometheusMetrics) RecordCacheMiss(cacheType string) {
+	switch cacheType {
+	case "certificate":
+		certCacheMissesCounter.Inc()
+	case "bundle":
+		bundleCacheMissesCounter.Inc()
+	}
+}
+
+// RecordRefresh records a certificate refresh.
+func (m *PrometheusMetrics) RecordRefresh(reason string, duration float64) {
+	certRefreshCounter.WithLabelValues(reason).Inc()
+	certRefreshDuration.Observe(duration)
+}
+
+// UpdateCertExpiry updates the certificate expiry timestamp.
+func (m *PrometheusMetrics) UpdateCertExpiry(serviceName string, expiryTime float64) {
+	certExpiryTimestamp.WithLabelValues(serviceName).Set(expiryTime)
+}
+
+// RecordValidation records a certificate validation result.
+func (m *PrometheusMetrics) RecordValidation(success bool) {
+	result := "failure"
+	if success {
+		result = "success"
+	}
+	certValidationCounter.WithLabelValues(result).Inc()
+}
+
+// RecordRetry records a provider retry attempt.
+func (m *PrometheusMetrics) RecordRetry(providerType string, attempt int) {
+	providerRetryCounter.WithLabelValues(providerType, strconv.Itoa(attempt)).Inc()
+}

--- a/internal/core/services/BUILD.bazel
+++ b/internal/core/services/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "services",
-    srcs = ["identity_service.go"],
+    srcs = [
+        "identity_service.go",
+        "metrics.go",
+    ],
     importpath = "github.com/sufield/ephemos/internal/core/services",
     visibility = ["//:__subpackages__"],
     deps = [

--- a/internal/core/services/identity_service_edge_cases_test.go
+++ b/internal/core/services/identity_service_edge_cases_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	metricsadapter "github.com/sufield/ephemos/internal/adapters/metrics"
 	"github.com/sufield/ephemos/internal/core/domain"
 	"github.com/sufield/ephemos/internal/core/ports"
 	"github.com/sufield/ephemos/internal/core/services"
@@ -26,7 +27,7 @@ func TestIdentityService_CacheMetrics_EdgeCases(t *testing.T) {
 	mockTransport := &MockTransportProvider{}
 
 	// Create service with Prometheus metrics for testing
-	metrics := services.NewPrometheusMetrics()
+	metrics := metricsadapter.NewPrometheusMetrics()
 	service, err := services.NewIdentityService(mockProvider, mockTransport, config, nil, metrics)
 	if err != nil {
 		t.Fatalf("Failed to create IdentityService: %v", err)
@@ -37,7 +38,7 @@ func TestIdentityService_CacheMetrics_EdgeCases(t *testing.T) {
 		if service == nil {
 			t.Error("Service should not be nil")
 		}
-		// Metrics are now tracked through Prometheus - integration would require 
+		// Metrics are now tracked through Prometheus - integration would require
 		// Prometheus client testing which is beyond the scope of unit tests
 	})
 
@@ -197,7 +198,7 @@ func TestIdentityService_ThreadSafety_EdgeCases(t *testing.T) {
 		for i := 0; i < numGoroutines; i++ {
 			go func() {
 				defer wg.Done()
-				
+
 				// Attempt to create server identity concurrently
 				_, err := service.CreateServerIdentity()
 				if err != nil {
@@ -225,7 +226,7 @@ func TestIdentityService_ThreadSafety_EdgeCases(t *testing.T) {
 
 		select {
 		case <-done:
-			t.Logf("Concurrent operations completed: %d successes, %d errors", 
+			t.Logf("Concurrent operations completed: %d successes, %d errors",
 				atomic.LoadInt64(&successCount), atomic.LoadInt64(&errorCount))
 			// At least some operations should complete without hanging
 		case <-time.After(15 * time.Second):
@@ -258,7 +259,7 @@ func TestIdentityService_ProactiveRefresh_EdgeCases(t *testing.T) {
 	t.Run("negative refresh threshold", func(t *testing.T) {
 		config := &ports.Configuration{
 			Service: ports.ServiceConfig{
-				Name:   "test-service", 
+				Name:   "test-service",
 				Domain: "example.com",
 				Cache: &ports.CacheConfig{
 					TTLMinutes:              10,

--- a/internal/core/services/metrics.go
+++ b/internal/core/services/metrics.go
@@ -1,66 +1,7 @@
 // Package services provides core business logic services.
 package services
 
-import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-)
-
-var (
-	// Certificate cache metrics
-	certCacheHitsCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "ephemos_cert_cache_hits_total",
-		Help: "Total number of certificate cache hits",
-	})
-	
-	certCacheMissesCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "ephemos_cert_cache_misses_total",
-		Help: "Total number of certificate cache misses",
-	})
-	
-	// Trust bundle cache metrics
-	bundleCacheHitsCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "ephemos_bundle_cache_hits_total",
-		Help: "Total number of trust bundle cache hits",
-	})
-	
-	bundleCacheMissesCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "ephemos_bundle_cache_misses_total",
-		Help: "Total number of trust bundle cache misses",
-	})
-	
-	// Certificate refresh metrics
-	certRefreshCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "ephemos_cert_refresh_total",
-		Help: "Total number of certificate refreshes",
-	}, []string{"reason"}) // reason: expired, proactive, cache_miss
-	
-	certRefreshDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "ephemos_cert_refresh_duration_seconds",
-		Help:    "Duration of certificate refresh operations",
-		Buckets: prometheus.DefBuckets,
-	})
-	
-	// Certificate expiry gauge
-	certExpiryTimestamp = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "ephemos_cert_expiry_timestamp_seconds",
-		Help: "Unix timestamp when the cached certificate will expire",
-	}, []string{"service_name"})
-	
-	// Certificate validation metrics
-	certValidationCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "ephemos_cert_validation_total",
-		Help: "Total number of certificate validations",
-	}, []string{"result"}) // result: success, failure
-	
-	// Retry metrics
-	providerRetryCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "ephemos_provider_retry_total",
-		Help: "Total number of provider retry attempts",
-	}, []string{"provider_type", "attempt"})
-)
-
-// MetricsReporter interface for reporting metrics
+// MetricsReporter defines contract for reporting identity service metrics.
 type MetricsReporter interface {
 	RecordCacheHit(cacheType string)
 	RecordCacheMiss(cacheType string)
@@ -70,76 +11,23 @@ type MetricsReporter interface {
 	RecordRetry(providerType string, attempt int)
 }
 
-// PrometheusMetrics implements MetricsReporter using Prometheus
-type PrometheusMetrics struct{}
-
-// NewPrometheusMetrics creates a new Prometheus metrics reporter
-func NewPrometheusMetrics() *PrometheusMetrics {
-	return &PrometheusMetrics{}
-}
-
-// RecordCacheHit records a cache hit
-func (m *PrometheusMetrics) RecordCacheHit(cacheType string) {
-	switch cacheType {
-	case "certificate":
-		certCacheHitsCounter.Inc()
-	case "bundle":
-		bundleCacheHitsCounter.Inc()
-	}
-}
-
-// RecordCacheMiss records a cache miss
-func (m *PrometheusMetrics) RecordCacheMiss(cacheType string) {
-	switch cacheType {
-	case "certificate":
-		certCacheMissesCounter.Inc()
-	case "bundle":
-		bundleCacheMissesCounter.Inc()
-	}
-}
-
-// RecordRefresh records a certificate refresh
-func (m *PrometheusMetrics) RecordRefresh(reason string, duration float64) {
-	certRefreshCounter.WithLabelValues(reason).Inc()
-	certRefreshDuration.Observe(duration)
-}
-
-// UpdateCertExpiry updates the certificate expiry timestamp
-func (m *PrometheusMetrics) UpdateCertExpiry(serviceName string, expiryTime float64) {
-	certExpiryTimestamp.WithLabelValues(serviceName).Set(expiryTime)
-}
-
-// RecordValidation records a certificate validation result
-func (m *PrometheusMetrics) RecordValidation(success bool) {
-	result := "failure"
-	if success {
-		result = "success"
-	}
-	certValidationCounter.WithLabelValues(result).Inc()
-}
-
-// RecordRetry records a provider retry attempt
-func (m *PrometheusMetrics) RecordRetry(providerType string, attempt int) {
-	providerRetryCounter.WithLabelValues(providerType, string(rune(attempt+'0'))).Inc()
-}
-
-// NoOpMetrics implements MetricsReporter with no-op methods for when metrics are disabled
+// NoOpMetrics implements MetricsReporter with no-op methods for when metrics are disabled.
 type NoOpMetrics struct{}
 
-// RecordCacheHit no-op implementation
+// RecordCacheHit no-op implementation.
 func (m *NoOpMetrics) RecordCacheHit(cacheType string) {}
 
-// RecordCacheMiss no-op implementation
+// RecordCacheMiss no-op implementation.
 func (m *NoOpMetrics) RecordCacheMiss(cacheType string) {}
 
-// RecordRefresh no-op implementation
+// RecordRefresh no-op implementation.
 func (m *NoOpMetrics) RecordRefresh(reason string, duration float64) {}
 
-// UpdateCertExpiry no-op implementation
+// UpdateCertExpiry no-op implementation.
 func (m *NoOpMetrics) UpdateCertExpiry(serviceName string, expiryTime float64) {}
 
-// RecordValidation no-op implementation
+// RecordValidation no-op implementation.
 func (m *NoOpMetrics) RecordValidation(success bool) {}
 
-// RecordRetry no-op implementation
+// RecordRetry no-op implementation.
 func (m *NoOpMetrics) RecordRetry(providerType string, attempt int) {}


### PR DESCRIPTION
## Summary
- remove Prometheus dependencies from core services package
- implement Prometheus metrics adapter under `internal/adapters/metrics`
- update tests and build files to use metrics adapter

## Testing
- `go test ./...` *(interrupted: long-running test in internal/adapters/primary/api)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d9e8bdc48327b4a226eebdac430f